### PR TITLE
Add User-Agent string generation

### DIFF
--- a/helpers/useragent/android.js
+++ b/helpers/useragent/android.js
@@ -1,0 +1,209 @@
+class AndroidUserAgentList {
+    constructor(options){
+        this.androidList = {
+            "10": {
+                "QKQ1.190825.002": [
+                    "Mi 9T"
+                ],
+                "QP1A.190711.020": [
+                    "SM-A515F",
+                    "SM-A750GN",
+                    "SM-N960F"
+                ]
+            },
+            "9": {
+                "PKQ1.190714.001": [
+                    "CPH1933"
+                ],
+                "PKQ1.190630.001": [
+                    "CPH1907"
+                ],
+                "PKQ1.190319.001": [
+                    "Redmi 7A",
+                    "Redmi 8",
+                    "Redmi 8A"
+                ],
+                "PKQ1.181021.001": [
+                    "Mi A3",
+                    "Redmi 7",
+                    "Redmi Y3"
+                ],
+                "PKQ1.180904.001": [
+                    "Redmi Note 5",
+                    "Redmi Note 7"
+                ],
+                "PPR1.180610.011": [
+                    "CPH1823",
+                    "CPH1989",
+                    "CPH1969",
+                    "CPH1923",
+                    "CPH2001",
+                    "CPH2083",
+                    "Redmi 6",
+                    "Redmi 6A",
+                    "Redmi Note 8 Pro",
+                    "SM-A750GN",
+                    "SM-G950F",
+                    "SM-G960F",
+                    "SM-G965F",
+                    "SM-N960F"
+                ]
+            },
+            "8.1.0": {
+                "M1AJQ": [
+                    "SM-G610F",
+                    "SM-J530F",
+                    "SM-M105F",
+                    "SM-N960F"
+                ],
+                "O11019": [
+                    "CPH1909",
+                    "vivo 1726",
+                    "vivo 1803",
+                    "vivo 1806",
+                    "vivo 1808",
+                    "vivo 1812",
+                    "vivo 1814",
+                    "vivo 1816",
+                    "vivo 1820"
+                ],
+                "OPM1.171019.026": [
+                    "CPH1853",
+                    "CPH1901",
+                    "V1818A",
+                    "vivo 1716",
+                    "vivo 1718",
+                    "vivo 1723",
+                    "vivo 1727",
+                    "vivo 1805",
+                    "vivo 1807",
+                    "vivo 1811",
+                    "vivo 1817",
+                    "vivo 1850"
+                ]
+            },
+            "8.0.0": {
+                "R16NW": [
+                    "SM-A600G",
+                    "SM-A750GN"
+                ]
+            },
+            "7.1.2": {
+                "N2G47H": [
+                    "vivo 1611",
+                    "vivo 1716",
+                    "vivo 1718",
+                    "vivo 1719",
+                    "vivo 1850",
+                    "vivo X9",
+                    "vivo X9L",
+                    "vivo X9Plus L",
+                    "vivo Y66i A",
+                    "vivo Y79",
+                    "vivo Y79A"
+                ]
+            },
+            "7.1.1": {
+                "N6F26Q": [
+                    "CPH1729",
+                    "vivo Y75A"
+                ],
+                "NMF26F": [
+                    "CPH1801",
+                    "vivo Xplay6"
+                ]
+            },
+            "7.0": {
+                "NRD90M": [
+                    "SM-G610F",
+                    "vivo 1612",
+                    "vivo 1713",
+                    "vivo 1714"
+                ]
+            },
+            "6.0.1": {
+                "MMB29M": [
+                    "SM-G930F",
+                    "SM-G930FD",
+                    "vivo 1603",
+                    "vivo 1606",
+                    "vivo 1606A",
+                    "vivo 1610",
+                    "vivo Y55",
+                    "vivo Y55A",
+                    "vivo Y66"
+                ],
+                "RB3N5C": [
+                    "RedMi Note 5"
+                ]
+            },
+            "6.0": {
+                "MRA58K": [
+                    "LG-K420",
+                    "LG-K430",
+                    "vivo 1601",
+                    "vivo 1609",
+                    "vivo 1713",
+                    "vivo Y67A",
+                    "vivo Y67L"
+                ]
+            },
+            "5.1.1": {
+                "LMY47V": [
+                    "A37f",
+                    "LG-K420",
+                    "SM-A9000",
+                    "vivo V3",
+                    "vivo V3Max",
+                    "vivo V3Max A",
+                    "vivo X6S A",
+                    "vivo X7",
+                    "vivo X7Plus",
+                    "vivo Y21L",
+                    "vivo Y31L",
+                    "vivo Y51L"
+                ]
+            },
+            "5.0.2": {
+                "LRX22G": [
+                    "SM-A500F",
+                    "SM-G530H",
+                    "vivo Y31A",
+                    "vivo Y51",
+                    "vivo Y51L"
+                ]
+            }
+        }
+
+
+        // Currently, the "uaType" is set to Firefox by default, since we need to research more about Chrome UAs
+        this.uaType = options.uaType || "firefox"
+        
+        if (!options.androidVersion || !this.androidList[options.androidVersion]) options.androidVersion = "9"
+        this.androidVersion = options.androidVersion
+        if (!options.androidBuildVersion || !this.androidList[options.androidVersion][options.androidBuildVersion]){
+            // Get a valid Android release build number
+            let list = Object.keys(this.androidList[options.androidVersion])
+            options.androidBuildVersion = list[Math.floor(Math.random() * list.length)]
+        }
+        this.androidBuildVersion = options.androidBuildVersion
+        if (!options.androidDevice){
+            // Get a valid Android device list
+            let list = this.androidList[options.androidVersion][options.androidBuildVersion]
+            options.androidDevice = list[Math.floor(Math.random() * list.length)]
+        }
+        this.androidDevice = options.androidDevice
+
+        // Optional: Firefox for Mobile version. If not specified, we will generate a new one based on the new Firefox for Android browser (Codename: Fenix)
+        this.firefoxVersion = options.firefoxVersion || Math.floor(79 + Math.random() * (82 - 79))
+    }
+    toString(){
+        // Detect the uaType
+        switch (this.uaType){
+            case "dalvik": return `Dalvik/2.1.0; U; Android ${this.androidVersion}; ${this.androidDevice} Build/${this.androidBuildVersion})`
+            case "firefox": return `Mozilla/5.0 (Android ${this.androidVersion}; Mobile; rv:${this.firefoxVersion}.0) Gecko/${this.firefoxVersion}.0 Firefox/${this.firefoxVersion}.0`
+        }
+    }
+}
+
+module.exports = AndroidUserAgentList

--- a/helpers/useragent/handler.js
+++ b/helpers/useragent/handler.js
@@ -1,0 +1,43 @@
+const AndroidUserAgentList = require('./android')
+const IosUserAgentList = require('./ios')
+
+class UserAgentHandler {
+    constructor(){
+        this.androidUserAgents = [
+            'Dalvik/2.1.0 (Linux; U; Android 10; SM-A750GN Build/QP1A.190711.020)'
+        ]
+        this.defaultVersions = {
+            // Definitions for "default versions" of operating systems and client apps
+            // Note that for Android, the default version chosen is "Android 9" (API Level 28) due to highest market share in Indonesia
+            binus: "1.13.0",
+            android: "9",
+            androidApiLevel: 28,
+            ios: "14.0.1",
+            
+            // The iOS Safari Build number now freezes to "15E148" for compatibility and privacy reasons
+            // Source: https://webkit.org/blog/8042/release-notes-for-safari-technology-preview-46/
+            iosSafariBuild: "15E148",
+    
+            // Alamofire (https://github.com/Alamofire/Alamofire) is a Swift library to handle HTTP requests for iOS apps
+            // The default version set corresponds to the library version used in the latest BINUS Mobile app
+            alamofire: "5.0.0"
+        }
+    }
+    getAndroidUserAgent(options){
+        // Override uaType to Dalvik to reflect the HTTP request from the actual app
+        options.uaType = "dalvik"
+        return new AndroidUserAgentList(options).toString()
+    }
+    getIosUserAgent(options){
+        // Override uaType to Binus to reflect the HTTP request from the actual app
+        options.uaType = "binus"
+        options.binusVersion = this.defaultVersions.binus
+        return new IosUserAgentList(options).toString()
+    }
+    getMobileUserAgent(options){
+        if (options.platform && options.platform == "ios") return getIosUserAgent(options)
+        else getAndroidUserAgent(options)
+    }
+}
+
+module.exports = UserAgentHandler

--- a/helpers/useragent/ios.js
+++ b/helpers/useragent/ios.js
@@ -37,7 +37,7 @@ class IosUserAgentList {
         // Detect the uaType
         switch (this.uaType){
             case "safari": return `Mozilla/5.0 (iPhone; CPU iPhone OS ${options.iosVersion.replace('.', '_')} like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/${options.iosVersion} Mobile/${options.safariBuildVersion} Safari/604.1`
-            case "binus": return `BINUS Student/${option.binusVersion} (com.binus-itdivision.mobilestudent; build:1; iOS ${options.iosVersion}) Alamofire/5.0.0`
+            case "binus": return `BINUS Student/${this.binusVersion} (com.binus-itdivision.mobilestudent; build:1; iOS ${options.iosVersion}) Alamofire/5.0.0`
         }
     }
 }

--- a/helpers/useragent/ios.js
+++ b/helpers/useragent/ios.js
@@ -36,8 +36,8 @@ class IosUserAgentList {
     toString(){
         // Detect the uaType
         switch (this.uaType){
-            case "safari": return `Mozilla/5.0 (iPhone; CPU iPhone OS ${options.iosVersion.replace('.', '_')} like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/${options.iosVersion} Mobile/${options.safariBuildVersion} Safari/604.1`
-            case "binus": return `BINUS Student/${this.binusVersion} (com.binus-itdivision.mobilestudent; build:1; iOS ${options.iosVersion}) Alamofire/5.0.0`
+            case "safari": return `Mozilla/5.0 (iPhone; CPU iPhone OS ${this.iosVersion.replace('.', '_')} like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/${this.iosVersion} Mobile/${this.safariBuildVersion} Safari/604.1`
+            case "binus": return `BINUS Student/${this.binusVersion} (com.binus-itdivision.mobilestudent; build:1; iOS ${this.iosVersion}) Alamofire/5.0.0`
         }
     }
 }

--- a/helpers/useragent/ios.js
+++ b/helpers/useragent/ios.js
@@ -31,7 +31,7 @@ class IosUserAgentList {
         this.iosVersion = options.iosVersion
         this.safariBuildVersion = this.iosList[options.iosVersion]
 
-        this.binusVersion = options.binusVersion
+        this.binusVersion = options.binusVersion || "1.13.0"
     }
     toString(){
         // Detect the uaType

--- a/helpers/useragent/ios.js
+++ b/helpers/useragent/ios.js
@@ -1,0 +1,45 @@
+class IosUserAgentList {
+    constructor(options){
+        // Note: For compatibility with the mobile app, we will only list iOS releases from 10 onwards
+        // The build number "15E148" is assigned on iOS 12 onwards to mimic behavior of Safari User Agents (to prevent fingerprinting)
+        this.iosList = {
+            "14.0": "15E148",
+            "14.0.1": "15E148",
+            "13.0": "15E148",
+            "13.1": "15E148",
+            "13.1.1": "15E148",
+            "13.1.2": "15E148",
+            "13.1.3": "15E148",
+            "13.2": "15E148",
+            "13.2.1": "15E148",
+            "13.2.2": "15E148",
+            "13.2.3": "15E148",
+            "13.3": "15E148",
+            "13.3.1": "15E148",
+            "13.4": "15E148",
+            "13.4.1": "15E148",
+            "13.5": "15E148",
+            "13.5.1": "15E148",
+            "13.6": "15E148",
+            "13.6.1": "15E148",
+            "13.7": "15E148"
+        }
+
+        this.uaType = options.uaType || "safari"
+
+        if (!options.iosVersion || !this.iosList[options.iosVersion]) options.iosVersion = "14.0.1"
+        this.iosVersion = options.iosVersion
+        this.safariBuildVersion = this.iosList[options.iosVersion]
+
+        this.binusVersion = options.binusVersion
+    }
+    toString(){
+        // Detect the uaType
+        switch (this.uaType){
+            case "safari": return `Mozilla/5.0 (iPhone; CPU iPhone OS ${options.iosVersion.replace('.', '_')} like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/${options.iosVersion} Mobile/${options.safariBuildVersion} Safari/604.1`
+            case "binus": return `BINUS Student/${option.binusVersion} (com.binus-itdivision.mobilestudent; build:1; iOS ${options.iosVersion}) Alamofire/5.0.0`
+        }
+    }
+}
+
+module.exports = IosUserAgentList

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const Auth = require('./adapters/auth')
 const Api = require('./adapters/api')
 const Enkerip = require('enkerip')
 const Request = require('./helpers/request')
+const UserAgentHandler = require('./helpers/useragent/handler')
 const axios = require('axios');
 const AVAILABLE_ADAPTERS = { auth: Auth, api: Api }
 
@@ -35,7 +36,12 @@ class Bijing {
 
         // * plugin and mixin installation
         this.$request = new Request(enkerip)
-        this.$axios = axios.create({ baseURL: this.$options.baseUrl })
+        this.$axios = axios.create({
+            baseURL: this.$options.baseUrl,
+            headers: {
+                'User-Agent': new UserAgentHandler().getIosUserAgent()
+            }
+        })
     }
 
     useAdapter (name, options = {}) {


### PR DESCRIPTION
I recently added a User Agent string generator which simulates requests from the original app.

In Android, the format of the UA string is similar to `Dalvik/2.1.0; U; Android 9; Redmi 7 Build/PKQ1.181021.001)`, while on iOS it would be similar to `BINUS Student/1.13.0 (com.binus-itdivision.mobilestudent; build:1; iOS 14.0.1) Alamofire/5.0.0`.

This new generator should be able to remove references to Axios while sending requests to the API server.